### PR TITLE
Try fixing miniconda path error on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ env:
   global: # For deploying the site to Github Pages
     - secure: jzcxV3nJ4VuPZr1tzhrV8NXeo3CZfUJlmU96xhsIXeZ89Ncu0J+yPqfBy6xmk5EDGzCEGYkJkLULm3gAHIodqK8BGGZpvjBVXWoNu+a8eqqIXYI0BKXVEydkusW4oofH041QdGSbmju6nL8UFnhtLwZhfbWJ2YcKI5IONl0yv6w=
   matrix:
-    - PYTHON=2.7
+    - PYTHON=3.4
 
 before_install:
   # Get Miniconda from Continuum
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - export PATH=/home/travis/miniconda3/bin:$PATH
   # Update conda itself
   - conda update --yes conda
   # Initialize the Pelican plugins submodule

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PY=python
 PELICAN=pelican
 PELICANOPTS=
 CONDAENV=pinga-site
+PYTHON=3.4
 BASEDIR=$(CURDIR)
 INPUTDIR=$(BASEDIR)/content
 OUTPUTDIR=$(BASEDIR)/output
@@ -43,7 +44,7 @@ publish:
 setup: install_requires
 
 mkenv:
-	conda create -n $(CONDAENV) --yes pip python=2.7
+	conda create -n $(CONDAENV) --yes pip python=$(PYTHON)
 
 install_requires: mkenv
 	bash -c "source activate $(CONDAENV) && pip install -r requirements.txt"


### PR DESCRIPTION
The default path is not /miniconda anymore but /miniconda2. Take this
change to update to python 3.4 and see if the fixes the problem as well
