### PR TITLE
Allow using a secondary email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Optional:
     picture: uieda.jpg
     github: leouieda
     email: bla@on.br
+    email2: meh@gmail.com
     scholar: http://scholar.google.com.br/citations?user=qfmPrUEAAAAJ
     researcherid: G-3258-2012
     researchgate: https://www.researchgate.net/profile/Leonardo_Uieda

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -93,7 +93,15 @@
     {% if this.email is defined %}
         <li class="list-group-item">
             <i class="fa fa-envelope fa-fw"></i>
-            e-mail: <a href="mailto:{{this.email}}">{{this.email}}</a>
+            e-mail{% if this.email2 is defined %} (primary){% endif %}:
+            <a href="mailto:{{this.email}}">{{this.email}}</a>
+        </li>
+    {% endif %}
+
+    {% if this.email2 is defined %}
+        <li class="list-group-item">
+            <i class="fa fa-envelope fa-fw"></i>
+            e-mail (secondary): <a href="mailto:{{this.email2}}">{{this.email2}}</a>
         </li>
     {% endif %}
 

--- a/people/uieda.md
+++ b/people/uieda.md
@@ -9,6 +9,7 @@ website: http://www.leouieda.com
 picture: uieda.jpg
 github: leouieda
 email: leouieda@gmail.com
+email2: uieda@hawaii.edu
 scholar: http://scholar.google.com.br/citations?user=qfmPrUEAAAAJ
 researcherid: G-3258-2012
 researchgate: https://www.researchgate.net/profile/Leonardo_Uieda


### PR DESCRIPTION
If you define the "email2:" metadata entry for a person, this will add
an "email (secondary)" field to the info sidebar. It will also add a
"(primary)" to the first email.

Fixes #14

As requested by @birocoles