### PR TITLE
Update my information and my students

### DIFF
--- a/_layouts/people.html
+++ b/_layouts/people.html
@@ -1,21 +1,17 @@
 {% extends "page.html" %}
 
 
-{% macro render_person(person, position=True, institution=False) -%}
+{% macro render_person(person) -%}
+<a href="{{person.url}}">
     <div class="people-box">
         {% if person.picture is defined %}
             <img class="img-circle" src="/images/pic/{{person.picture}}"></img>
         {% else %}
-            <img class="img-circle picture" src="/images/pic/misc.png"></img>
+            <img class="img-circle" src="/images/pic/misc.png"></img>
         {% endif %}
-        <a href="{{person.url}}"><h3>{{person.title}}</h3></a>
-        {% if position %}
-            <p>{{ person.position }}</p>
-        {% endif %}
-        {% if institution %}
-            <p>{{ person.institution }}</p>
-        {% endif %}
-    </div>
+        <h3>{{person.title}}</h3>
+        <p> {{ person.position }} <br> {{ person.institution }} </p>
+    </div></a>
 {%- endmacro %}
 
 
@@ -23,26 +19,9 @@
 
     {{ super() }}
 
-    <h2>Professors</h2>
+    <h2>Current members</h2>
 
-    {% set profs = this.content|selectattr("position", "equalto", "Professor")|list + this.content|selectattr("position", "equalto", "Researcher")|list %}
-
-    {% for row in profs|rejectattr("former", "defined")|sort(attribute='date')|batch(3) %}
-        <div class="row">
-        {% for person in row %}
-            <div class="col-sm-4 col-md-4">
-                {{ render_person(person, position=False, institution=True) }}
-            </div>
-        {% endfor %}
-        </div>
-    {% endfor %}
-
-    <hr>
-    <h2>Students</h2>
-
-    {% set students = this.content|rejectattr("position", "equalto", "Professor")|rejectattr("position", "equalto", "Researcher") %}
-
-    {% for row in students|rejectattr("former", "defined")|sort(attribute='date')|batch(3) %}
+    {% for row in this.content|rejectattr("former", "defined")|sort(attribute='date')|batch(3) %}
         <div class="row">
         {% for person in row %}
             <div class="col-sm-4 col-md-4">

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -168,15 +168,11 @@
         </ul>
     {% endif %}
 
-    {% if this.position in ["Researcher", "Professor"] %}
-        {# Convert generators to lists so that they can used again and test if
-           they are empty #}
-
-        {% set students = site.reflinks["/people"].content|selectattr("advisor", "defined")|reverse|list %}
-        {% set mine_ad = students|selectattr("advisor", "equalto", this.components[-1])|list %}
-        {% set mine_co = students|selectattr("coadvisor", "defined")|selectattr("coadvisor", "equalto", this.components[-1])|list %}
-        {% set mine = mine_ad + mine_co %}
-
+    {% set students = site.reflinks["/people"].content|selectattr("advisor", "defined")|reverse|list %}
+    {% set mine_ad = students|selectattr("advisor", "equalto", this.components[-1])|list %}
+    {% set mine_co = students|selectattr("coadvisor", "defined")|selectattr("coadvisor", "equalto", this.components[-1])|list %}
+    {% set mine = mine_ad + mine_co %}
+    {% if mine %}
         {% set current = mine|rejectattr("former", "defined")|list %}
         {% if current %}
             {{ list_students(current, "Current students") }}

--- a/css/style.css
+++ b/css/style.css
@@ -178,7 +178,8 @@ footer a:hover {
 }
 
 .people-box p {
-    font-size: 14pt;
+    font-size: 12pt;
+    color: #999999;
 }
 
 .people-box h2 {

--- a/index.md
+++ b/index.md
@@ -14,14 +14,17 @@ and some of our [published papers](/papers).
 
 In the spirit of **open-science** and **reproducibility**,
 we try to provide the source code and data used for our papers.
-Most new papers will have links to a [GitHub repository](http://github.com/)
+Most new papers will have links to a
+[GitHub repository](http://github.com/pinga-lab)
 for code and a [DOI](http://en.wikipedia.org/wiki/Digital_object_identifier)
 (from [figshare](http://figshare.com/) or [Zenodo](https://zenodo.org/))
 for data and other supplementary material.
 
-We are based in the [Observatório Nacional](http://www.on.br/)
-and the [Universidade do Estado do Rio de Janeiro](http://www.uerj.br/),
-both in Rio de Janeiro, Brazil.
+We are based at the
+[Observatório Nacional](http://www.on.br/) in Rio de Janeiro, Brazil,
+and the
+[University of Hawaii at Manoa](http://www.soest.hawaii.edu/GG/) in Honolulu,
+USA.
 
 # Contact
 

--- a/people/barbosa.md
+++ b/people/barbosa.md
@@ -1,6 +1,6 @@
 ---
 title: Valéria C. F. Barbosa
-date: 2016-01-01
+date: 2010-01-01
 lattes: http://lattes.cnpq.br/0391036221142471
 picture: barbosa.jpg
 github: valcris

--- a/people/gatts.md
+++ b/people/gatts.md
@@ -7,9 +7,10 @@ picture: gatts.jpg
 <!--github: -->
 position: Undergraduate student
 advisor: uieda
-period: 2016-Present
+period: 2016-2017
 institution: Universidade do Estado do Rio de Janeiro
 location: Rio de Janeiro, Brazil
+former: true
 layout: person
 ---
 

--- a/people/oliveira-jr.md
+++ b/people/oliveira-jr.md
@@ -1,6 +1,6 @@
 ---
 title: Vanderlei C. Oliveira Jr.
-date: 2016-01-02
+date: 2010-01-02
 lattes: http://lattes.cnpq.br/4332841435949533
 picture: oliveira-jr.jpg
 email: vandscoelho@gmail.com

--- a/people/riguete.md
+++ b/people/riguete.md
@@ -5,9 +5,10 @@ lattes: http://lattes.cnpq.br/5860438547039334
 picture: riguete.jpg
 position: Undergraduate student
 advisor: uieda
-period: 2015-Present
+period: 2015-2017
 institution: Universidade do Estado do Rio de Janeiro
 location: Rio de Janeiro, Brazil
+former: true
 layout: person
 ---
 

--- a/people/uieda.md
+++ b/people/uieda.md
@@ -1,9 +1,9 @@
 ---
 title: Leonardo Uieda
-date: 2016-01-03
-institution: Universidade do Estado do Rio de Janeiro
-location: Rio de Janeiro, Brasil
-position: Professor
+date: 2010-01-03
+institution: University of Hawaii at Manoa
+location: Honolulu, HI, USA
+position: Research Affiliate
 lattes: http://lattes.cnpq.br/8939551682050504
 website: http://www.leouieda.com
 picture: uieda.jpg
@@ -20,27 +20,32 @@ layout: person
 
 # About
 
-I'm a geophysicist working mainly on inverse problems in gravity and magnetics.
-
-Starting February 2014,
-I'm working as Professor of Geophysics at the
-<a href="http://www.uerj.br">Universidade do Estado do Rio de Janeiro</a>,
+I am currently working at the
+[University of Hawaii at Manoa](http://www.soest.hawaii.edu/GG/index.html)
+where I'm developing the
+[Python bindings for the Generic Mapping Tools](https://www.gmtpython.xyz/)
+and doing research in inverse problems and interpolation of geodetic data.
+Prior to coming here, I worked for 4 years as Assistant Professor of Geophysics
+at the [Universidade do Estado do Rio de Janeiro (UERJ)](http://www.uerj.br),
 Brazil.
-I teach the "Intro to Geophysics" courses to Geology students,
-<a href="http://www.leouieda.com/teaching/">among others</a>.
-A typical day at work usually involves a lot of
-<a href="http://www.leouieda.com/software">open-source software development</a>,
-for both research and teaching.
-My language of choice is [Python](https://www.python.org/).
-I'm one of the founders and main developer of
-[Fatiando a Terra](http://www.fatiando.org).
+There, I developed and taught courses in geophysics and
+programming and numerical methods.
+I received my PhD from the Observatório Nacional, Brazil, for the
+creation of the open-source software [Tesseroid](http://www.tesseroids.org) and
+[Fatiando a Terra](https://www.fatiando.org/) and for my
+[work on large-scale gravity inversion][/papers/paper-moho-inversion-tesseroids-2016].
+
+My research focuses on inverse problems in potential field
+geophysics with a heavy dose of open-source software development.
+I do my best to bring more openness to the scientific process
+and to train the next generation of scientists in the best practices of
+reproducible computational experiments.
 
 In the spirit of open-science,
 I share all of the research and
 teaching material online under permissive licenses.
-You'll find links to source code, images, lessons, etc, scattered around
-my [personal website](http://www.leouieda.com)
-(look for the <i class="fa fa-github-square fa-fw"></i> icon).
+You'll find links to source code, images, lessons, etc,
+throughout my [personal website](http://www.leouieda.com).
 
 Follow me on [Twitter (@leouieda)](https://twitter.com/leouieda)
 and [Github (@leouieda)](https://github.com/leouieda)

--- a/people/victortxa.md
+++ b/people/victortxa.md
@@ -5,8 +5,9 @@ lattes: http://lattes.cnpq.br/1873679068917169
 github: victortxa
 institution: Universidade do Estado do Rio de Janeiro
 location: Rio de Janeiro, Brasil
-position: Qualitec Scholarship technician
-period: 2014-Present
+position: Technician
+period: 2014-2018
+former: true
 layout: person
 ---
 


### PR DESCRIPTION
Mark students from UERJ as former and update my affiliation to UH.

Made some tweaks to the templates to make it work for other position
titles other than Researcher or Professor. Also removed the break
between profs and students. Just separate current and former. Profs are
highlighted by keeping them first on the list (using the page date to
sort).