### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -90,7 +90,7 @@
                     <li class="list-group-item">
                         {{ fa("paperclip", "fa-fw", "Supplementary material") }}
                         Supplement:
-                        <a href="http://dx.doi.org/{{this.supplement}}">{{this.supplement}}</a>
+                        <a href="https://doi.org/{{this.supplement}}">{{this.supplement}}</a>
                     </li>
                 {% endif %}
                 {% if this.sucupira is defined %}
@@ -110,7 +110,7 @@
                 {% if this.doi is defined %}
                     <li class="list-group-item">
                         {{ fa("external-link", "fa-fw", "DOI link to publisher") }}
-                        doi: <a href="http://dx.doi.org/{{this.doi}}">{{
+                        doi: <a href="https://doi.org/{{this.doi}}">{{
                             this.doi}}</a>
                     </li>
                 {% endif %}

--- a/papers/nmo-tutorial.md
+++ b/papers/nmo-tutorial.md
@@ -15,7 +15,7 @@ layout: publication
 # About
 
 *This is a part of The Leading Edge [tutorials
-series](https://dx.doi.org/10.1190/tle35020190.1).
+series](https://doi.org/10.1190/tle35020190.1).
 All tutorials are open-access and include open-source code examples.*
 
 The manuscript was written in [Authorea](https://www.authorea.com).

--- a/papers/paper-mag-dir-2015.md
+++ b/papers/paper-mag-dir-2015.md
@@ -30,7 +30,7 @@ for more information about using this class.
 
 This paper has undergone open peer-review.
 The original submission, reviews, and replies can be viewed at
-[doi:10.5194/npgd-1-1465-2014](http://dx.doi.org/10.5194/npgd-1-1465-2014).
+[doi:10.5194/npgd-1-1465-2014](https://doi.org/10.5194/npgd-1-1465-2014).
 
 # Abstract
 

--- a/papers/paper-magnetization-rock-sample-2016.md
+++ b/papers/paper-magnetization-rock-sample-2016.md
@@ -51,7 +51,7 @@ This article is protected by copyright. All rights reserved.
               title = {Estimating the magnetization distribution within rectangular rock samples},
               journal = {Geochemistry, Geophysics, Geosystems},
               issn = {1525-2027},
-              url = {http://dx.doi.org/10.1002/2016GC006329},
+              url = {https://doi.org/10.1002/2016GC006329},
               doi = {10.1002/2016GC006329},
               pages = {n/a--n/a},
               keywords = {Magnetic anomalies: modeling and interpretation, Instruments and techniques, Magnetostratigraphy, Computational models, algorithms, Inverse theory, magnetic anomalies, rock and mineral magnetism, instruments and techniques, paleomagnetism, magnetic inversion},

--- a/papers/paper-moho-inversion-tesseroids-2016.md
+++ b/papers/paper-moho-inversion-tesseroids-2016.md
@@ -27,11 +27,11 @@ We applied the inversion to estimate the Moho depth for South America.
 
 The main result from this publication is the gravity-derived Moho depth model
 for South America and the differences between it and seismological estimates
-of [Assumpção et al. (2013)](http://dx.doi.org/10.1016/j.tecto.2012.11.014).
+of [Assumpção et al. (2013)](https://doi.org/10.1016/j.tecto.2012.11.014).
 These differences allow us to know where the gravity-derived model can be trusted and where there might be unaccounted sources in the gravity data.
 
 You can **download** the model results, source code, and input data from
-doi:[10.6084/m9.figshare.3987267](https://dx.doi.org/10.6084/m9.figshare.3987267)
+doi:[10.6084/m9.figshare.3987267](https://doi.org/10.6084/m9.figshare.3987267)
 
 
 ![The estimated Moho depth for South America and differences with seismological estimates](https://raw.githubusercontent.com/pinga-lab/paper-moho-inversion-tesseroids/master/model/south-american-moho.png)

--- a/papers/paper-planting-anomalous-densities-2012.md
+++ b/papers/paper-planting-anomalous-densities-2012.md
@@ -27,7 +27,7 @@ of the library.
 The following is an animation of the growth algorithm
 during the inversion of synthetic data.
 The video is available at [figshare](http://figshare.com/):
-[10.6084/m9.figshare.91469](http://dx.doi.org/10.6084/m9.figshare.91469)
+[10.6084/m9.figshare.91469](https://doi.org/10.6084/m9.figshare.91469)
 
 <div class="embed-responsive embed-responsive-16by9">
 <iframe src="http://wl.figshare.com/articles/91469/embed?show_title=0"

--- a/papers/paper-tle-euler-tutorial-2014.md
+++ b/papers/paper-tle-euler-tutorial-2014.md
@@ -26,7 +26,7 @@ section in [The Leading Edge](http://library.seg.org/journal/leedff),
 started by Matt Hall of [Agile Geoscience](http://agilegeoscience.com/).
 All tutorials are Open-Access and include open-source code examples.
 Read the
-[February 2016 tutorial](http://dx.doi.org/10.1190/tle35020190.1) by Matt
+[February 2016 tutorial](https://doi.org/10.1190/tle35020190.1) by Matt
 for an introduction to the tutorial series
 and what you need to know to get started running the code in them.
 
@@ -48,7 +48,7 @@ usefulness and, most importantly, call attention to some pitfalls encountered
 in the interpretation of the results. The code and synthetic data required to
 reproduce our results and figures can be found in the accompanying IPython
 notebooks ([ipython.org/notebook](http://ipython.org/notebook))
-at [dx.doi.org/10.6084/m9.figshare.923450](http://dx.doi.org/10.6084/m9.figshare.923450)
+at [dx.doi.org/10.6084/m9.figshare.923450](https://doi.org/10.6084/m9.figshare.923450)
 or [github.com/pinga-lab/paper-tle-euler-tutorial](https://github.com/pinga-lab/paper-tle-euler-tutorial).
 The notebooks also expand the
 analysis presented here. We encourage you to download the data and try it on


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!